### PR TITLE
Fix the error : ValueError: could not convert string to float: 'Index…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2](https://github.com/ssenart/PyGazpar/compare/1.0.1...1.0.2) - 2021-11-25
+### Fixed
+- Fix broken command line pygazpar caused by adding the new lastNDays parameter.
+- Fix the error : ValueError: could not convert string to float: 'Index de début de période (m3)'. It occurs because the records in the Excel file now starts at line 10 instead of line 8 before (thanks to DEFAYArnaud(https://github.com/DEFAYArnaud) for having spotted the issue and bringing the fix).
+
+### Changed
+- In the Excel file, if a cell is empty, then no corresponding key will be inserted in the result dictionary (before we inserted a key with an empty string).
+
 ## [1.0.1](https://github.com/ssenart/PyGazpar/compare/1.0.0...1.0.1) - 2021-11-24
 ### Fixed
 - Fix typo warning from Pylance preventing 1.0.0 to be published.

--- a/pygazpar/__main__.py
+++ b/pygazpar/__main__.py
@@ -46,6 +46,11 @@ def main():
                         type=lambda frequency: pygazpar.Frequency[frequency], choices=list(pygazpar.Frequency),
                         default="DAILY",
                         help="Meter reading frequency (DAILY, WEEKLY, MONTHLY)")
+    parser.add_argument("-d", "--lastNDays",
+                        required=False,
+                        type=int,
+                        default=365,
+                        help="Get only the last N days of records (default: 365 days)")
     parser.add_argument("--testMode",
                         required=False,
                         action='store_true',
@@ -78,9 +83,10 @@ def main():
     logging.info(f"--lastNRows {int(args.lastNRows)}")
     logging.info(f"--headfull {bool(args.headfull)}")
     logging.info(f"--frequency {args.frequency}")
+    logging.info(f"--lastNDays {args.lastNDays}")
     logging.info(f"--testMode {bool(args.testMode)}")
 
-    client = pygazpar.Client(args.username, args.password, args.webdriver, int(args.wait_time), args.tmpdir, int(args.lastNRows), not bool(args.headfull), args.frequency, bool(args.testMode))
+    client = pygazpar.Client(args.username, args.password, args.webdriver, int(args.wait_time), args.tmpdir, int(args.lastNRows), not bool(args.headfull), args.frequency, int(args.lastNDays), bool(args.testMode))
 
     try:
         client.update()

--- a/pygazpar/datafileparser.py
+++ b/pygazpar/datafileparser.py
@@ -7,6 +7,9 @@ from openpyxl.cell.cell import Cell
 from openpyxl import load_workbook
 
 
+FIRST_DATA_LINE_NUMBER = 10
+
+
 # ------------------------------------------------------------------------------------------------------------
 class DataFileParser:
 
@@ -56,8 +59,6 @@ class DataFileParser:
                     row[propertyName] = float(cell.value)
             else:
                 row[propertyName] = cell.value
-        else:
-            row[propertyName] = ""
 
     # ------------------------------------------------------
     @staticmethod
@@ -73,7 +74,7 @@ class DataFileParser:
         # Timestamp of the data.
         data_timestamp = datetime.now().isoformat()
 
-        minRowNum = max(8, len(worksheet['B']) + 1 - lastNRows) if lastNRows > 0 else 8
+        minRowNum = max(FIRST_DATA_LINE_NUMBER, len(worksheet['B']) + 1 - lastNRows) if lastNRows > 0 else FIRST_DATA_LINE_NUMBER
         maxRowNum = len(worksheet['B'])
         for rownum in range(minRowNum, maxRowNum + 1):
             row = {}
@@ -102,7 +103,7 @@ class DataFileParser:
         # Timestamp of the data.
         data_timestamp = datetime.now().isoformat()
 
-        minRowNum = max(8, len(worksheet['B']) + 1 - lastNRows) if lastNRows > 0 else 8
+        minRowNum = max(FIRST_DATA_LINE_NUMBER, len(worksheet['B']) + 1 - lastNRows) if lastNRows > 0 else FIRST_DATA_LINE_NUMBER
         maxRowNum = len(worksheet['B'])
         for rownum in range(minRowNum, maxRowNum + 1):
             row = {}
@@ -126,7 +127,7 @@ class DataFileParser:
         # Timestamp of the data.
         data_timestamp = datetime.now().isoformat()
 
-        minRowNum = max(8, len(worksheet['B']) + 1 - lastNRows) if lastNRows > 0 else 8
+        minRowNum = max(FIRST_DATA_LINE_NUMBER, len(worksheet['B']) + 1 - lastNRows) if lastNRows > 0 else FIRST_DATA_LINE_NUMBER
         maxRowNum = len(worksheet['B'])
         for rownum in range(minRowNum, maxRowNum + 1):
             row = {}

--- a/tests/test_datafileparser.py
+++ b/tests/test_datafileparser.py
@@ -6,12 +6,21 @@ class TestDataFileParser:
 
     def test_daily_sample(self):
         data = DataFileParser.parse("tests/resources/Donnees_informatives_PCE_DAILY.xlsx", Frequency.DAILY, 10)
-        assert(len(data) > 0)
+        assert(len(data) == 10)
+
+        data = DataFileParser.parse("tests/resources/Donnees_informatives_PCE_DAILY.xlsx", Frequency.DAILY, 0)
+        assert(len(data) == 363)
 
     def test_weekly_sample(self):
         data = DataFileParser.parse("tests/resources/Donnees_informatives_PCE_WEEKLY.xlsx", Frequency.WEEKLY, 10)
-        assert(len(data) > 0)
+        assert(len(data) == 10)
+
+        data = DataFileParser.parse("tests/resources/Donnees_informatives_PCE_WEEKLY.xlsx", Frequency.WEEKLY, 0)
+        assert(len(data) == 53)
 
     def test_monthly_sample(self):
         data = DataFileParser.parse("tests/resources/Donnees_informatives_PCE_MONTHLY.xlsx", Frequency.MONTHLY, 10)
-        assert(len(data) > 0)
+        assert(len(data) == 10)
+
+        data = DataFileParser.parse("tests/resources/Donnees_informatives_PCE_MONTHLY.xlsx", Frequency.MONTHLY, 0)
+        assert(len(data) == 13)


### PR DESCRIPTION
… de début de période (m3)'.

### Fixed
- Fix broken command line pygazpar caused by adding the new lastNDays parameter.
- Fix the error : ValueError: could not convert string to float: 'Index de début de période (m3)'. It occurs because the records in the Excel file now starts at line 10 instead of line 8 before (thanks to DEFAYArnaud(https://github.com/DEFAYArnaud) for having spotted the issue and bringing the fix).

### Changed
- In the Excel file, if a cell is empty, then no corresponding key will be inserted in the result dictionary (before we inserted a key with an empty string).