### PR TITLE
Numéro PCE pas forcément un nombre

### DIFF
--- a/pygazpar/__main__.py
+++ b/pygazpar/__main__.py
@@ -20,8 +20,7 @@ def main():
                         required=True,
                         help="GRDF password")
     parser.add_argument("-c", "--pce",
-                        required=True,
-                        type=int,
+                        required=True,,
                         help="GRDF PCE identifier")
     parser.add_argument("-t", "--tmpdir",
                         required=False,
@@ -68,7 +67,7 @@ def main():
     logging.info(f"--lastNDays {args.lastNDays}")
     logging.info(f"--testMode {bool(args.testMode)}")
 
-    client = pygazpar.Client(args.username, args.password, int(args.pce), args.frequency, int(args.lastNDays), args.tmpdir, bool(args.testMode))
+    client = pygazpar.Client(args.username, args.password, args.pce, args.frequency, int(args.lastNDays), args.tmpdir, bool(args.testMode))
 
     try:
         client.update()

--- a/pygazpar/client.py
+++ b/pygazpar/client.py
@@ -34,7 +34,7 @@ class LoginError(Exception):
 class Client:
 
     # ------------------------------------------------------
-    def __init__(self, username: str, password: str, pceIdentifier: int, meterReadingFrequency: Frequency = DEFAULT_METER_READING_FREQUENCY, lastNDays: int = DEFAULT_LAST_N_DAYS, tmpDirectory: str = DEFAULT_TMP_DIRECTORY, testMode: bool = False):
+    def __init__(self, username: str, password: str, pceIdentifier: str, meterReadingFrequency: Frequency = DEFAULT_METER_READING_FREQUENCY, lastNDays: int = DEFAULT_LAST_N_DAYS, tmpDirectory: str = DEFAULT_TMP_DIRECTORY, testMode: bool = False):
         self.__username = username
         self.__password = password
         self.__pceIdentifier = pceIdentifier


### PR DESCRIPTION
Bonjour,
Le numéro PCE de mon compteur commence par un `0` et lorsque j'essaie de récupérer mes relevés avec PyGazpar, une erreur de l'API est renvoyée. Le numéro PCE ne doit donc pas être converti en `int` lorsque il est passé en paramètre mais doit être une `string`.
