### PR TITLE
github actions: do not publish the forks

### DIFF
--- a/.github/workflows/python-publish-develop.yml
+++ b/.github/workflows/python-publish-develop.yml
@@ -131,5 +131,5 @@ jobs:
         python updateVersion.py --nextVersion ${{ steps.gitversion.outputs.majorMinorPatch }}.dev${{ steps.gitversion.outputs.buildMetaData }}
         python setup.py sdist bdist_wheel --python-tag ${{ steps.python-tag.outputs.replaced }}
         twine upload --skip-existing --repository testpypi dist/*
-      if: ${{ matrix.python-version == 3.8}}
+      if: ${{ matrix.python-version == 3.8 && github.repository == 'ssenart/PyGazpar' }}
 

--- a/.github/workflows/python-publish-release.yml
+++ b/.github/workflows/python-publish-release.yml
@@ -83,3 +83,4 @@ jobs:
         python updateVersion.py --nextVersion ${{ github.event.release.tag_name }}
         python setup.py sdist bdist_wheel --python-tag ${{ steps.python-tag.outputs.replaced }}
         twine upload --skip-existing dist/*
+      if: github.repository == 'ssenart/PyGazpar'


### PR DESCRIPTION
Try to publish a new version **only** if the repository is the uptream one ssenart/PyGazpar.

Without the patch the github actions fails for forks.