### PR TITLE
Add Python 3.12 support 

### DIFF
--- a/.github/workflows/python-publish-develop.yml
+++ b/.github/workflows/python-publish-develop.yml
@@ -105,7 +105,7 @@ jobs:
         pytest tests --doctest-modules --junitxml=junit/test-results-${{ matrix.python-version }}.xml --cov=pygazpar --cov-report=xml --cov-report=html --log-cli-level=DEBUG --log-cli-format="%(asctime)s %(levelname)s [%(name)s] %(message)s"
 
     - name: Upload pytest test results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: pytest-results-${{ matrix.python-version }}
         path: |

--- a/.github/workflows/python-publish-develop.yml
+++ b/.github/workflows/python-publish-develop.yml
@@ -19,7 +19,7 @@ jobs:
         - "3.9"
         - "3.10"
         - "3.11"
-        
+        - "3.12"
     steps:
 
     - name: Checkout

--- a/.github/workflows/python-publish-release.yml
+++ b/.github/workflows/python-publish-release.yml
@@ -21,7 +21,7 @@ jobs:
         - "3.9"
         - "3.10"
         - "3.11"
-
+        - "3.12"  
     steps:
 
     - uses: actions/checkout@v2

--- a/.github/workflows/python-publish-release.yml
+++ b/.github/workflows/python-publish-release.yml
@@ -57,7 +57,7 @@ jobs:
         pytest tests --doctest-modules --junitxml=junit/test-results-${{ matrix.python-version }}.xml --cov=com --cov-report=xml --cov-report=html --log-cli-level=DEBUG --log-cli-format="%(asctime)s %(levelname)s [%(name)s] %(message)s"
 
     - name: Upload pytest test results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: pytest-results-${{ matrix.python-version }}
         path: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.3](https://github.com/ssenart/PyGazpar/compare/1.2.3...1.2.1) - 2024-10-05
+
+### Added
+- [#70](https://github.com/ssenart/PyGazpar/issues/70): Add Python 3.12 support.
+
 ## [1.2.2](https://github.com/ssenart/PyGazpar/compare/1.2.1...1.2.2) - 2024-05-08
 
 ### Fixed

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11       
-
+    Programming Language :: Python :: 3.12
 [options]
 zip_safe = False
 include_package_data = True


### PR DESCRIPTION
### Added
- [#70](https://github.com/ssenart/PyGazpar/issues/70): Add Python 3.12 support.